### PR TITLE
Acl rules refactor

### DIFF
--- a/test/patches/acl_rules.js
+++ b/test/patches/acl_rules.js
@@ -13,750 +13,83 @@ module.exports = {
       }]
     },
 
-    //models
-    /**
-     * Model: accession
-     */
+    // model permissions
     {
       roles: 'editor',
       allows: [{
-        resources: 'accession',
-        permissions: 'create'
+        resources: [
+                  'accession',
+                  'acl_validations',
+                  'aminoacidsequence',
+                  'arr',
+                  'capital',
+                  'country',
+                  'country_to_river',
+                  'cultivar',
+                  'dog',
+                  'field_plot',
+                  'individual',
+                  'location',
+                  'mM1',
+                  'mM1_to_MM2',
+                  'mM2',
+                  'measurement',
+                  'microbiome_asv',
+                  'oM1',
+                  'oM2',
+                  'parrot',
+                  'person',
+                  'plant_measurement',
+                  'pot',
+                  'river',
+                  'sample',
+                  'sample_measurement',
+                  'sequencingExperiment',
+                  'taxon',
+                  'transcript_count',
+                  'with_validations',
+                ],
+        permissions: ['create', 'update', 'delete']
       }]
     },
-    {
-      roles: 'reader',
-      allows: [{
-        resources: 'accession',
-        permissions: 'read'
-      }]
-    },
-    {
-      roles: 'editor',
-      allows: [{
-        resources: 'accession',
-        permissions: 'update'
-      }]
-    },
-    {
-      roles: 'editor',
-      allows: [{
-        resources: 'accession',
-        permissions: 'delete'
-      }]
-    },
-    /**
-     * Model: acl_validations
-     */
-    {
-      roles: 'editor',
-      allows: [{
-        resources: 'acl_validations',
-        permissions: 'create'
-      }]
-    },
+
     {
       roles: 'reader',
       allows: [{
-        resources: 'acl_validations',
-        permissions: 'read'
-      }]
-    },
-    {
-      roles: 'editor',
-      allows: [{
-        resources: 'acl_validations',
-        permissions: 'update'
-      }]
-    },
-    {
-      roles: 'editor',
-      allows: [{
-        resources: 'acl_validations',
-        permissions: 'delete'
-      }]
-    },
-    /**
-     * Model: aminoacidsequence
-     */
-    {
-      roles: 'editor',
-      allows: [{
-        resources: 'aminoacidsequence',
-        permissions: 'create'
-      }]
-    },
-    {
-      roles: 'reader',
-      allows: [{
-        resources: 'aminoacidsequence',
-        permissions: 'read'
-      }]
-    },
-    {
-      roles: 'editor',
-      allows: [{
-        resources: 'aminoacidsequence',
-        permissions: 'update'
-      }]
-    },
-    {
-      roles: 'editor',
-      allows: [{
-        resources: 'aminoacidsequence',
-        permissions: 'delete'
-      }]
-    },
-    /**
-     * Model: capital
-     */
-    {
-      roles: 'editor',
-      allows: [{
-        resources: 'capital',
-        permissions: 'create'
-      }]
-    },
-    {
-      roles: 'reader',
-      allows: [{
-        resources: 'capital',
-        permissions: 'read'
-      }]
-    },
-    {
-      roles: 'editor',
-      allows: [{
-        resources: 'capital',
-        permissions: 'update'
-      }]
-    },
-    {
-      roles: 'editor',
-      allows: [{
-        resources: 'capital',
-        permissions: 'delete'
-      }]
-    },
-    /**
-     * Model: country
-     */
-    {
-      roles: 'editor',
-      allows: [{
-        resources: 'country',
-        permissions: 'create'
-      }]
-    },
-    {
-      roles: 'reader',
-      allows: [{
-        resources: 'country',
-        permissions: 'read'
-      }]
-    },
-    {
-      roles: 'editor',
-      allows: [{
-        resources: 'country',
-        permissions: 'update'
-      }]
-    },
-    {
-      roles: 'editor',
-      allows: [{
-        resources: 'country',
-        permissions: 'delete'
-      }]
-    },
-    /**
-     * Model: country_to_river
-     */
-    {
-      roles: 'editor',
-      allows: [{
-        resources: 'country_to_river',
-        permissions: 'create'
-      }]
-    },
-    {
-      roles: 'reader',
-      allows: [{
-        resources: 'country_to_river',
-        permissions: 'read'
-      }]
-    },
-    {
-      roles: 'editor',
-      allows: [{
-        resources: 'country_to_river',
-        permissions: 'update'
-      }]
-    },
-    {
-      roles: 'editor',
-      allows: [{
-        resources: 'country_to_river',
-        permissions: 'delete'
-      }]
-    },
-    /**
-     * Model: cultivar
-     */
-    {
-      roles: 'editor',
-      allows: [{
-        resources: 'cultivar',
-        permissions: 'create'
-      }]
-    },
-    {
-      roles: 'reader',
-      allows: [{
-        resources: 'cultivar',
-        permissions: 'read'
-      }]
-    },
-    {
-      roles: 'editor',
-      allows: [{
-        resources: 'cultivar',
-        permissions: 'update'
-      }]
-    },
-    {
-      roles: 'editor',
-      allows: [{
-        resources: 'cultivar',
-        permissions: 'delete'
-      }]
-    },
-    /**
-     * Model: dog
-     */
-    {
-      roles: 'editor',
-      allows: [{
-        resources: 'dog',
-        permissions: 'create'
-      }]
-    },
-    {
-      roles: 'reader',
-      allows: [{
-        resources: 'dog',
-        permissions: 'read'
-      }]
-    },
-    {
-      roles: 'editor',
-      allows: [{
-        resources: 'dog',
-        permissions: 'update'
-      }]
-    },
-    {
-      roles: 'editor',
-      allows: [{
-        resources: 'dog',
-        permissions: 'delete'
-      }]
-    },
-    /**
-     * Model: field_plot
-     */
-    {
-      roles: 'editor',
-      allows: [{
-        resources: 'field_plot',
-        permissions: 'create'
-      }]
-    },
-    {
-      roles: 'reader',
-      allows: [{
-        resources: 'field_plot',
-        permissions: 'read'
-      }]
-    },
-    {
-      roles: 'editor',
-      allows: [{
-        resources: 'field_plot',
-        permissions: 'update'
-      }]
-    },
-    {
-      roles: 'editor',
-      allows: [{
-        resources: 'field_plot',
-        permissions: 'delete'
-      }]
-    },
-    /**
-     * Model: individual
-     */
-    {
-      roles: 'editor',
-      allows: [{
-        resources: 'individual',
-        permissions: 'create'
-      }]
-    },
-    {
-      roles: 'reader',
-      allows: [{
-        resources: 'individual',
-        permissions: 'read'
-      }]
-    },
-    {
-      roles: 'editor',
-      allows: [{
-        resources: 'individual',
-        permissions: 'update'
-      }]
-    },
-    {
-      roles: 'editor',
-      allows: [{
-        resources: 'individual',
-        permissions: 'delete'
-      }]
-    },
-    /**
-     * Model: location
-     */
-    {
-      roles: 'editor',
-      allows: [{
-        resources: 'location',
-        permissions: 'create'
-      }]
-    },
-    {
-      roles: 'reader',
-      allows: [{
-        resources: 'location',
-        permissions: 'read'
-      }]
-    },
-    {
-      roles: 'editor',
-      allows: [{
-        resources: 'location',
-        permissions: 'update'
-      }]
-    },
-    {
-      roles: 'editor',
-      allows: [{
-        resources: 'location',
-        permissions: 'delete'
-      }]
-    },
-    /**
-     * Model: measurement
-     */
-    {
-      roles: 'editor',
-      allows: [{
-        resources: 'measurement',
-        permissions: 'create'
-      }]
-    },
-    {
-      roles: 'reader',
-      allows: [{
-        resources: 'measurement',
-        permissions: 'read'
-      }]
-    },
-    {
-      roles: 'editor',
-      allows: [{
-        resources: 'measurement',
-        permissions: 'update'
-      }]
-    },
-    {
-      roles: 'editor',
-      allows: [{
-        resources: 'measurement',
-        permissions: 'delete'
-      }]
-    },
-    /**
-     * Model: microbiome_asv
-     */
-    {
-      roles: 'editor',
-      allows: [{
-        resources: 'microbiome_asv',
-        permissions: 'create'
-      }]
-    },
-    {
-      roles: 'reader',
-      allows: [{
-        resources: 'microbiome_asv',
-        permissions: 'read'
-      }]
-    },
-    {
-      roles: 'editor',
-      allows: [{
-        resources: 'microbiome_asv',
-        permissions: 'update'
-      }]
-    },
-    {
-      roles: 'editor',
-      allows: [{
-        resources: 'microbiome_asv',
-        permissions: 'delete'
-      }]
-    },
-    /**
-     * Model: parrot
-     */
-    {
-      roles: 'editor',
-      allows: [{
-        resources: 'parrot',
-        permissions: 'create'
-      }]
-    },
-    {
-      roles: 'reader',
-      allows: [{
-        resources: 'parrot',
-        permissions: 'read'
-      }]
-    },
-    {
-      roles: 'editor',
-      allows: [{
-        resources: 'parrot',
-        permissions: 'update'
-      }]
-    },
-    {
-      roles: 'editor',
-      allows: [{
-        resources: 'parrot',
-        permissions: 'delete'
-      }]
-    },
-    /**
-     * Model: person
-     */
-    {
-      roles: 'editor',
-      allows: [{
-        resources: 'person',
-        permissions: 'create'
-      }]
-    },
-    {
-      roles: 'reader',
-      allows: [{
-        resources: 'person',
-        permissions: 'read'
-      }]
-    },
-    {
-      roles: 'editor',
-      allows: [{
-        resources: 'person',
-        permissions: 'update'
-      }]
-    },
-    {
-      roles: 'editor',
-      allows: [{
-        resources: 'person',
-        permissions: 'delete'
-      }]
-    },
-    /**
-     * Model: plant_measurement
-     */
-    {
-      roles: 'editor',
-      allows: [{
-        resources: 'plant_measurement',
-        permissions: 'create'
-      }]
-    },
-    {
-      roles: 'reader',
-      allows: [{
-        resources: 'plant_measurement',
-        permissions: 'read'
-      }]
-    },
-    {
-      roles: 'editor',
-      allows: [{
-        resources: 'plant_measurement',
-        permissions: 'update'
-      }]
-    },
-    {
-      roles: 'editor',
-      allows: [{
-        resources: 'plant_measurement',
-        permissions: 'delete'
-      }]
-    },
-    /**
-     * Model: pot
-     */
-    {
-      roles: 'editor',
-      allows: [{
-        resources: 'pot',
-        permissions: 'create'
-      }]
-    },
-    {
-      roles: 'reader',
-      allows: [{
-        resources: 'pot',
-        permissions: 'read'
-      }]
-    },
-    {
-      roles: 'editor',
-      allows: [{
-        resources: 'pot',
-        permissions: 'update'
-      }]
-    },
-    {
-      roles: 'editor',
-      allows: [{
-        resources: 'pot',
-        permissions: 'delete'
-      }]
-    },
-    /**
-     * Model: river
-     */
-    {
-      roles: 'editor',
-      allows: [{
-        resources: 'river',
-        permissions: 'create'
-      }]
-    },
-    {
-      roles: 'reader',
-      allows: [{
-        resources: 'river',
-        permissions: 'read'
-      }]
-    },
-    {
-      roles: 'editor',
-      allows: [{
-        resources: 'river',
-        permissions: 'update'
-      }]
-    },
-    {
-      roles: 'editor',
-      allows: [{
-        resources: 'river',
-        permissions: 'delete'
-      }]
-    },
-    /**
-     * Model: sample
-     */
-    {
-      roles: 'editor',
-      allows: [{
-        resources: 'sample',
-        permissions: 'create'
-      }]
-    },
-    {
-      roles: 'reader',
-      allows: [{
-        resources: 'sample',
-        permissions: 'read'
-      }]
-    },
-    {
-      roles: 'editor',
-      allows: [{
-        resources: 'sample',
-        permissions: 'update'
-      }]
-    },
-    {
-      roles: 'editor',
-      allows: [{
-        resources: 'sample',
-        permissions: 'delete'
-      }]
-    },
-    /**
-     * Model: sample_measurement
-     */
-    {
-      roles: 'editor',
-      allows: [{
-        resources: 'sample_measurement',
-        permissions: 'create'
-      }]
-    },
-    {
-      roles: 'reader',
-      allows: [{
-        resources: 'sample_measurement',
-        permissions: 'read'
-      }]
-    },
-    {
-      roles: 'editor',
-      allows: [{
-        resources: 'sample_measurement',
-        permissions: 'update'
-      }]
-    },
-    {
-      roles: 'editor',
-      allows: [{
-        resources: 'sample_measurement',
-        permissions: 'delete'
-      }]
-    },
-    /**
-     * Model: sequencingExperiment
-     */
-    {
-      roles: 'editor',
-      allows: [{
-        resources: 'sequencingExperiment',
-        permissions: 'create'
-      }]
-    },
-    {
-      roles: 'reader',
-      allows: [{
-        resources: 'sequencingExperiment',
-        permissions: 'read'
-      }]
-    },
-    {
-      roles: 'editor',
-      allows: [{
-        resources: 'sequencingExperiment',
-        permissions: 'update'
-      }]
-    },
-    {
-      roles: 'editor',
-      allows: [{
-        resources: 'sequencingExperiment',
-        permissions: 'delete'
-      }]
-    },
-    /**
-     * Model: taxon
-     */
-    {
-      roles: 'editor',
-      allows: [{
-        resources: 'taxon',
-        permissions: 'create'
-      }]
-    },
-    {
-      roles: 'reader',
-      allows: [{
-        resources: 'taxon',
-        permissions: 'read'
-      }]
-    },
-    {
-      roles: 'editor',
-      allows: [{
-        resources: 'taxon',
-        permissions: 'update'
-      }]
-    },
-    {
-      roles: 'editor',
-      allows: [{
-        resources: 'taxon',
-        permissions: 'delete'
-      }]
-    },
-    /**
-     * Model: transcript_count
-     */
-    {
-      roles: 'editor',
-      allows: [{
-        resources: 'transcript_count',
-        permissions: 'create'
-      }]
-    },
-    {
-      roles: 'reader',
-      allows: [{
-        resources: 'transcript_count',
-        permissions: 'read'
-      }]
-    },
-    {
-      roles: 'editor',
-      allows: [{
-        resources: 'transcript_count',
-        permissions: 'update'
-      }]
-    },
-    {
-      roles: 'editor',
-      allows: [{
-        resources: 'transcript_count',
-        permissions: 'delete'
-      }]
-    },
-    /**
-     * Model: with_validations
-     */
-    {
-      roles: 'editor',
-      allows: [{
-        resources: 'with_validations',
-        permissions: 'create'
-      }]
-    },
-    {
-      roles: 'reader',
-      allows: [{
-        resources: 'with_validations',
-        permissions: 'read'
-      }]
-    },
-    {
-      roles: 'editor',
-      allows: [{
-        resources: 'with_validations',
-        permissions: 'update'
-      }]
-    },
-    {
-      roles: 'editor',
-      allows: [{
-        resources: 'with_validations',
-        permissions: 'delete'
-      }]
-    },
+        resources: [
+                  'accession',
+                  'acl_validations',
+                  'aminoacidsequence',
+                  'arr',
+                  'capital',
+                  'country',
+                  'country_to_river',
+                  'cultivar',
+                  'dog',
+                  'field_plot',
+                  'individual',
+                  'location',
+                  'mM1',
+                  'mM1_to_MM2',
+                  'mM2',
+                  'measurement',
+                  'microbiome_asv',
+                  'oM1',
+                  'oM2',
+                  'parrot',
+                  'person',
+                  'plant_measurement',
+                  'pot',
+                  'river',
+                  'sample',
+                  'sample_measurement',
+                  'sequencingExperiment',
+                  'taxon',
+                  'transcript_count',
+                  'with_validations',
+                ],
+        permissions: ['read']
+      }]
+    }
   ]
 }

--- a/test/patches/acl_rules.js.patch
+++ b/test/patches/acl_rules.js.patch
@@ -1,5 +1,5 @@
---- acl_rules.js	2020-07-27 23:01:33.599007183 -0500
-+++ acl_rules.js.patched	2020-07-27 23:01:58.032149695 -0500
+--- acl_rules.js	2021-01-05 10:34:54.861666483 +0100
++++ acl_rules.js.patched	2021-01-05 10:35:05.929483682 +0100
 @@ -13,6 +13,17 @@
        }]
      },
@@ -14,7 +14,7 @@
 +        permissions: '*'
 +      }]
 +    },
-+
-     //models
-     /**
-      * Model: accession
++    
+     // model permissions
+     {
+       roles: 'editor',

--- a/test/patches/acl_rules.js.patched
+++ b/test/patches/acl_rules.js.patched
@@ -23,751 +23,84 @@ module.exports = {
         permissions: '*'
       }]
     },
+    
+    // model permissions
+    {
+      roles: 'editor',
+      allows: [{
+        resources: [
+                  'accession',
+                  'acl_validations',
+                  'aminoacidsequence',
+                  'arr',
+                  'capital',
+                  'country',
+                  'country_to_river',
+                  'cultivar',
+                  'dog',
+                  'field_plot',
+                  'individual',
+                  'location',
+                  'mM1',
+                  'mM1_to_MM2',
+                  'mM2',
+                  'measurement',
+                  'microbiome_asv',
+                  'oM1',
+                  'oM2',
+                  'parrot',
+                  'person',
+                  'plant_measurement',
+                  'pot',
+                  'river',
+                  'sample',
+                  'sample_measurement',
+                  'sequencingExperiment',
+                  'taxon',
+                  'transcript_count',
+                  'with_validations',
+                ],
+        permissions: ['create', 'update', 'delete']
+      }]
+    },
 
-    //models
-    /**
-     * Model: accession
-     */
-    {
-      roles: 'editor',
-      allows: [{
-        resources: 'accession',
-        permissions: 'create'
-      }]
-    },
     {
       roles: 'reader',
       allows: [{
-        resources: 'accession',
-        permissions: 'read'
-      }]
-    },
-    {
-      roles: 'editor',
-      allows: [{
-        resources: 'accession',
-        permissions: 'update'
-      }]
-    },
-    {
-      roles: 'editor',
-      allows: [{
-        resources: 'accession',
-        permissions: 'delete'
-      }]
-    },
-    /**
-     * Model: acl_validations
-     */
-    {
-      roles: 'editor',
-      allows: [{
-        resources: 'acl_validations',
-        permissions: 'create'
-      }]
-    },
-    {
-      roles: 'reader',
-      allows: [{
-        resources: 'acl_validations',
-        permissions: 'read'
-      }]
-    },
-    {
-      roles: 'editor',
-      allows: [{
-        resources: 'acl_validations',
-        permissions: 'update'
-      }]
-    },
-    {
-      roles: 'editor',
-      allows: [{
-        resources: 'acl_validations',
-        permissions: 'delete'
-      }]
-    },
-    /**
-     * Model: aminoacidsequence
-     */
-    {
-      roles: 'editor',
-      allows: [{
-        resources: 'aminoacidsequence',
-        permissions: 'create'
-      }]
-    },
-    {
-      roles: 'reader',
-      allows: [{
-        resources: 'aminoacidsequence',
-        permissions: 'read'
-      }]
-    },
-    {
-      roles: 'editor',
-      allows: [{
-        resources: 'aminoacidsequence',
-        permissions: 'update'
-      }]
-    },
-    {
-      roles: 'editor',
-      allows: [{
-        resources: 'aminoacidsequence',
-        permissions: 'delete'
-      }]
-    },
-    /**
-     * Model: capital
-     */
-    {
-      roles: 'editor',
-      allows: [{
-        resources: 'capital',
-        permissions: 'create'
-      }]
-    },
-    {
-      roles: 'reader',
-      allows: [{
-        resources: 'capital',
-        permissions: 'read'
-      }]
-    },
-    {
-      roles: 'editor',
-      allows: [{
-        resources: 'capital',
-        permissions: 'update'
-      }]
-    },
-    {
-      roles: 'editor',
-      allows: [{
-        resources: 'capital',
-        permissions: 'delete'
-      }]
-    },
-    /**
-     * Model: country
-     */
-    {
-      roles: 'editor',
-      allows: [{
-        resources: 'country',
-        permissions: 'create'
-      }]
-    },
-    {
-      roles: 'reader',
-      allows: [{
-        resources: 'country',
-        permissions: 'read'
-      }]
-    },
-    {
-      roles: 'editor',
-      allows: [{
-        resources: 'country',
-        permissions: 'update'
-      }]
-    },
-    {
-      roles: 'editor',
-      allows: [{
-        resources: 'country',
-        permissions: 'delete'
-      }]
-    },
-    /**
-     * Model: country_to_river
-     */
-    {
-      roles: 'editor',
-      allows: [{
-        resources: 'country_to_river',
-        permissions: 'create'
-      }]
-    },
-    {
-      roles: 'reader',
-      allows: [{
-        resources: 'country_to_river',
-        permissions: 'read'
-      }]
-    },
-    {
-      roles: 'editor',
-      allows: [{
-        resources: 'country_to_river',
-        permissions: 'update'
-      }]
-    },
-    {
-      roles: 'editor',
-      allows: [{
-        resources: 'country_to_river',
-        permissions: 'delete'
-      }]
-    },
-    /**
-     * Model: cultivar
-     */
-    {
-      roles: 'editor',
-      allows: [{
-        resources: 'cultivar',
-        permissions: 'create'
-      }]
-    },
-    {
-      roles: 'reader',
-      allows: [{
-        resources: 'cultivar',
-        permissions: 'read'
-      }]
-    },
-    {
-      roles: 'editor',
-      allows: [{
-        resources: 'cultivar',
-        permissions: 'update'
-      }]
-    },
-    {
-      roles: 'editor',
-      allows: [{
-        resources: 'cultivar',
-        permissions: 'delete'
-      }]
-    },
-    /**
-     * Model: dog
-     */
-    {
-      roles: 'editor',
-      allows: [{
-        resources: 'dog',
-        permissions: 'create'
-      }]
-    },
-    {
-      roles: 'reader',
-      allows: [{
-        resources: 'dog',
-        permissions: 'read'
-      }]
-    },
-    {
-      roles: 'editor',
-      allows: [{
-        resources: 'dog',
-        permissions: 'update'
-      }]
-    },
-    {
-      roles: 'editor',
-      allows: [{
-        resources: 'dog',
-        permissions: 'delete'
-      }]
-    },
-    /**
-     * Model: field_plot
-     */
-    {
-      roles: 'editor',
-      allows: [{
-        resources: 'field_plot',
-        permissions: 'create'
-      }]
-    },
-    {
-      roles: 'reader',
-      allows: [{
-        resources: 'field_plot',
-        permissions: 'read'
-      }]
-    },
-    {
-      roles: 'editor',
-      allows: [{
-        resources: 'field_plot',
-        permissions: 'update'
-      }]
-    },
-    {
-      roles: 'editor',
-      allows: [{
-        resources: 'field_plot',
-        permissions: 'delete'
-      }]
-    },
-    /**
-     * Model: individual
-     */
-    {
-      roles: 'editor',
-      allows: [{
-        resources: 'individual',
-        permissions: 'create'
-      }]
-    },
-    {
-      roles: 'reader',
-      allows: [{
-        resources: 'individual',
-        permissions: 'read'
-      }]
-    },
-    {
-      roles: 'editor',
-      allows: [{
-        resources: 'individual',
-        permissions: 'update'
-      }]
-    },
-    {
-      roles: 'editor',
-      allows: [{
-        resources: 'individual',
-        permissions: 'delete'
-      }]
-    },
-    /**
-     * Model: location
-     */
-    {
-      roles: 'editor',
-      allows: [{
-        resources: 'location',
-        permissions: 'create'
-      }]
-    },
-    {
-      roles: 'reader',
-      allows: [{
-        resources: 'location',
-        permissions: 'read'
-      }]
-    },
-    {
-      roles: 'editor',
-      allows: [{
-        resources: 'location',
-        permissions: 'update'
-      }]
-    },
-    {
-      roles: 'editor',
-      allows: [{
-        resources: 'location',
-        permissions: 'delete'
-      }]
-    },
-    /**
-     * Model: measurement
-     */
-    {
-      roles: 'editor',
-      allows: [{
-        resources: 'measurement',
-        permissions: 'create'
-      }]
-    },
-    {
-      roles: 'reader',
-      allows: [{
-        resources: 'measurement',
-        permissions: 'read'
-      }]
-    },
-    {
-      roles: 'editor',
-      allows: [{
-        resources: 'measurement',
-        permissions: 'update'
-      }]
-    },
-    {
-      roles: 'editor',
-      allows: [{
-        resources: 'measurement',
-        permissions: 'delete'
-      }]
-    },
-    /**
-     * Model: microbiome_asv
-     */
-    {
-      roles: 'editor',
-      allows: [{
-        resources: 'microbiome_asv',
-        permissions: 'create'
-      }]
-    },
-    {
-      roles: 'reader',
-      allows: [{
-        resources: 'microbiome_asv',
-        permissions: 'read'
-      }]
-    },
-    {
-      roles: 'editor',
-      allows: [{
-        resources: 'microbiome_asv',
-        permissions: 'update'
-      }]
-    },
-    {
-      roles: 'editor',
-      allows: [{
-        resources: 'microbiome_asv',
-        permissions: 'delete'
-      }]
-    },
-    /**
-     * Model: parrot
-     */
-    {
-      roles: 'editor',
-      allows: [{
-        resources: 'parrot',
-        permissions: 'create'
-      }]
-    },
-    {
-      roles: 'reader',
-      allows: [{
-        resources: 'parrot',
-        permissions: 'read'
-      }]
-    },
-    {
-      roles: 'editor',
-      allows: [{
-        resources: 'parrot',
-        permissions: 'update'
-      }]
-    },
-    {
-      roles: 'editor',
-      allows: [{
-        resources: 'parrot',
-        permissions: 'delete'
-      }]
-    },
-    /**
-     * Model: person
-     */
-    {
-      roles: 'editor',
-      allows: [{
-        resources: 'person',
-        permissions: 'create'
-      }]
-    },
-    {
-      roles: 'reader',
-      allows: [{
-        resources: 'person',
-        permissions: 'read'
-      }]
-    },
-    {
-      roles: 'editor',
-      allows: [{
-        resources: 'person',
-        permissions: 'update'
-      }]
-    },
-    {
-      roles: 'editor',
-      allows: [{
-        resources: 'person',
-        permissions: 'delete'
-      }]
-    },
-    /**
-     * Model: plant_measurement
-     */
-    {
-      roles: 'editor',
-      allows: [{
-        resources: 'plant_measurement',
-        permissions: 'create'
-      }]
-    },
-    {
-      roles: 'reader',
-      allows: [{
-        resources: 'plant_measurement',
-        permissions: 'read'
-      }]
-    },
-    {
-      roles: 'editor',
-      allows: [{
-        resources: 'plant_measurement',
-        permissions: 'update'
-      }]
-    },
-    {
-      roles: 'editor',
-      allows: [{
-        resources: 'plant_measurement',
-        permissions: 'delete'
-      }]
-    },
-    /**
-     * Model: pot
-     */
-    {
-      roles: 'editor',
-      allows: [{
-        resources: 'pot',
-        permissions: 'create'
-      }]
-    },
-    {
-      roles: 'reader',
-      allows: [{
-        resources: 'pot',
-        permissions: 'read'
-      }]
-    },
-    {
-      roles: 'editor',
-      allows: [{
-        resources: 'pot',
-        permissions: 'update'
-      }]
-    },
-    {
-      roles: 'editor',
-      allows: [{
-        resources: 'pot',
-        permissions: 'delete'
-      }]
-    },
-    /**
-     * Model: river
-     */
-    {
-      roles: 'editor',
-      allows: [{
-        resources: 'river',
-        permissions: 'create'
-      }]
-    },
-    {
-      roles: 'reader',
-      allows: [{
-        resources: 'river',
-        permissions: 'read'
-      }]
-    },
-    {
-      roles: 'editor',
-      allows: [{
-        resources: 'river',
-        permissions: 'update'
-      }]
-    },
-    {
-      roles: 'editor',
-      allows: [{
-        resources: 'river',
-        permissions: 'delete'
-      }]
-    },
-    /**
-     * Model: sample
-     */
-    {
-      roles: 'editor',
-      allows: [{
-        resources: 'sample',
-        permissions: 'create'
-      }]
-    },
-    {
-      roles: 'reader',
-      allows: [{
-        resources: 'sample',
-        permissions: 'read'
-      }]
-    },
-    {
-      roles: 'editor',
-      allows: [{
-        resources: 'sample',
-        permissions: 'update'
-      }]
-    },
-    {
-      roles: 'editor',
-      allows: [{
-        resources: 'sample',
-        permissions: 'delete'
-      }]
-    },
-    /**
-     * Model: sample_measurement
-     */
-    {
-      roles: 'editor',
-      allows: [{
-        resources: 'sample_measurement',
-        permissions: 'create'
-      }]
-    },
-    {
-      roles: 'reader',
-      allows: [{
-        resources: 'sample_measurement',
-        permissions: 'read'
-      }]
-    },
-    {
-      roles: 'editor',
-      allows: [{
-        resources: 'sample_measurement',
-        permissions: 'update'
-      }]
-    },
-    {
-      roles: 'editor',
-      allows: [{
-        resources: 'sample_measurement',
-        permissions: 'delete'
-      }]
-    },
-    /**
-     * Model: sequencingExperiment
-     */
-    {
-      roles: 'editor',
-      allows: [{
-        resources: 'sequencingExperiment',
-        permissions: 'create'
-      }]
-    },
-    {
-      roles: 'reader',
-      allows: [{
-        resources: 'sequencingExperiment',
-        permissions: 'read'
-      }]
-    },
-    {
-      roles: 'editor',
-      allows: [{
-        resources: 'sequencingExperiment',
-        permissions: 'update'
-      }]
-    },
-    {
-      roles: 'editor',
-      allows: [{
-        resources: 'sequencingExperiment',
-        permissions: 'delete'
-      }]
-    },
-    /**
-     * Model: taxon
-     */
-    {
-      roles: 'editor',
-      allows: [{
-        resources: 'taxon',
-        permissions: 'create'
-      }]
-    },
-    {
-      roles: 'reader',
-      allows: [{
-        resources: 'taxon',
-        permissions: 'read'
-      }]
-    },
-    {
-      roles: 'editor',
-      allows: [{
-        resources: 'taxon',
-        permissions: 'update'
-      }]
-    },
-    {
-      roles: 'editor',
-      allows: [{
-        resources: 'taxon',
-        permissions: 'delete'
-      }]
-    },
-    /**
-     * Model: transcript_count
-     */
-    {
-      roles: 'editor',
-      allows: [{
-        resources: 'transcript_count',
-        permissions: 'create'
-      }]
-    },
-    {
-      roles: 'reader',
-      allows: [{
-        resources: 'transcript_count',
-        permissions: 'read'
-      }]
-    },
-    {
-      roles: 'editor',
-      allows: [{
-        resources: 'transcript_count',
-        permissions: 'update'
-      }]
-    },
-    {
-      roles: 'editor',
-      allows: [{
-        resources: 'transcript_count',
-        permissions: 'delete'
-      }]
-    },
-    /**
-     * Model: with_validations
-     */
-    {
-      roles: 'editor',
-      allows: [{
-        resources: 'with_validations',
-        permissions: 'create'
-      }]
-    },
-    {
-      roles: 'reader',
-      allows: [{
-        resources: 'with_validations',
-        permissions: 'read'
-      }]
-    },
-    {
-      roles: 'editor',
-      allows: [{
-        resources: 'with_validations',
-        permissions: 'update'
-      }]
-    },
-    {
-      roles: 'editor',
-      allows: [{
-        resources: 'with_validations',
-        permissions: 'delete'
-      }]
-    },
+        resources: [
+                  'accession',
+                  'acl_validations',
+                  'aminoacidsequence',
+                  'arr',
+                  'capital',
+                  'country',
+                  'country_to_river',
+                  'cultivar',
+                  'dog',
+                  'field_plot',
+                  'individual',
+                  'location',
+                  'mM1',
+                  'mM1_to_MM2',
+                  'mM2',
+                  'measurement',
+                  'microbiome_asv',
+                  'oM1',
+                  'oM2',
+                  'parrot',
+                  'person',
+                  'plant_measurement',
+                  'pot',
+                  'river',
+                  'sample',
+                  'sample_measurement',
+                  'sequencingExperiment',
+                  'taxon',
+                  'transcript_count',
+                  'with_validations',
+                ],
+        permissions: ['read']
+      }]
+    }
   ]
 }

--- a/views/pages/acl/acl_rules.ejs
+++ b/views/pages/acl/acl_rules.ejs
@@ -13,39 +13,29 @@ module.exports = {
       }]
     },
 
-    //models
-<%for( let i=0; i<models.length; i++ ){-%>
-    /**
-     * Model: <%- models[i].nameLc %>
-     */
+    // model permissions
     {
       roles: 'editor',
       allows: [{
-        resources: '<%- models[i].nameLc _%>',
-        permissions: 'create'
+        resources: [
+        <%for( let i=0; i<models.length; i++ ){-%>
+          '<%- models[i].nameLc _%>',
+        <%}-%>
+        ],
+        permissions: ['create', 'update', 'delete']
       }]
     },
+
     {
       roles: 'reader',
       allows: [{
-        resources: '<%- models[i].nameLc _%>',
-        permissions: 'read'
+        resources: [
+        <%for( let i=0; i<models.length; i++ ){-%>
+          '<%- models[i].nameLc _%>',
+        <%}-%>
+        ],
+        permissions: ['read']
       }]
-    },
-    {
-      roles: 'editor',
-      allows: [{
-        resources: '<%- models[i].nameLc _%>',
-        permissions: 'update'
-      }]
-    },
-    {
-      roles: 'editor',
-      allows: [{
-        resources: '<%- models[i].nameLc _%>',
-        permissions: 'delete'
-      }]
-    },
-<%}-%>
+    }
   ]
 }


### PR DESCRIPTION
## issue

https://github.com/Zendro-dev/graphql-server-model-codegen/issues/175

## related PR

gql-codegen PR: https://github.com/Zendro-dev/graphql-server-model-codegen/pull/177

## Description

This PR implements issue #175 in the single-page-app-codegen. `acl_rules.js` acl configuration becomes much more readable/maintainable especially if a large number of roles/models were to be used.